### PR TITLE
Swap position of -ldl in CC command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ OBJS = fsync.o open.o
 CFLAGS = -O2 -g
 
 nosync.so: $(OBJS)
-	$(CC) -shared -fPIC -ldl -lpthread $(CFLAGS) -o $@ $+
+	$(CC) -shared -fPIC -lpthread $(CFLAGS) -o $@ $+ -ldl
 
 %.o: %.c
 	$(CC) -c -fPIC $(CFLAGS) -o $@ $+


### PR DESCRIPTION
For unknown reasons to me having the -ldl flag not at the end of the CC command fails.

On Ubuntu 18.04
```
LD_PRELOAD=/somepath/nosync.so cat
cat: symbol lookup error: /media/home/ppopieluch/nosync/nosync.so: undefined symbol: dlsym

```

ldd output, note libdl is missing:
```
ldd nosync.so
        linux-vdso.so.1 (0x00007ffdf27e9000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f6a29b84000)
        /lib64/ld-linux-x86-64.so.2 (0x00007f6a2a177000)
```

After recompiling with the flag it is linked correctly:
```
ldd nosync.so
        linux-vdso.so.1 (0x00007ffd6ff25000)
        libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007f0c0ac9e000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f0c0a8ad000)
        /lib64/ld-linux-x86-64.so.2 (0x00007f0c0b0a4000)
```